### PR TITLE
feat: add a release command to build, commit and push automatically

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,6 +88,15 @@ change. It does this by reformating the entire file and running `git add` on
 the file after. This breaks workflows where you're trying to commit portions of
 the file only. You can always run your commit with `--no-verify`.
 
+## Making a release
+
+```sh
+$ npm version patch -m "release: %s"
+$ npm publish
+```
+
+`npm version` tests the code and build it. Then it upgrades the package version number according to the used keyword (patch, minor or major) and commit the modifications in Git (with a proper version tag). Finally, it pushes it to repository with the tag.
+
 ## Help needed
 
 Please checkout the [the open issues][issues]

--- a/package.json
+++ b/package.json
@@ -39,7 +39,9 @@
         "postinstall": "npm run build",
         "deploy": "npm publish",
         "contributors:add": "all-contributors add",
-        "contributors:generate": "all-contributors generate"
+        "contributors:generate": "all-contributors generate",
+        "preversion": "npm test && npm run build",
+        "postversion": "git push && git push --tags"
     },
     "devDependencies": {
         "@commitlint/cli": "^6.1.3",


### PR DESCRIPTION
@frosato-ekino See the CONTRIBUTING changes to understand the process.

It's related to our discussions about the dist folder: commit or not commit?

Spoiler: Not commit! The empty `.npmignore` is the key ;)