### PR TITLE
fix: the .npmignore official hack does not work, the file whitelist does

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
         "node": ">=8.9.1"
     },
     "main": "dist/index.js",
+    "files": [
+        "dist"
+	],
     "bin": {
         "knuckle": "dist/bin/index.js"
     },


### PR DESCRIPTION
This time I double checked that it is working ;)

When installing the module via NPM, the `dist` folder is the only one downloaded.